### PR TITLE
WIP: position-representation-agnostic implementations of CodeMap

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,9 @@ keywords = ["source", "position", "compiler", "sourcemap", "rustc"]
 
 [badges]
 travis-ci = { repository = "kevinmehall/codemap" }
+
+[features]
+generic = [ "num-traits" ]
+
+[dependencies]
+num-traits = { version = "^0.2", optional = true }


### PR DESCRIPTION
Codemap is really handy, but the restriction to 4GiB seems unnecessary on systems capable of supporting more in memory. 

This gives an implementation parameterised by some position representation type, which allows for CodeMaps which index the position by say `usize`, or simply any type with numerical properties.

The next step would be to remove all the code duplication between the existing implementation and the generified version, but I'm not sure how to proceed. Either
  * only compile the `u32` version directly if the feature isn't configured, and otherwise re-export aliases with `u32` in place of the parameter. This doesn't actually have less duplication
  *  use a macro to generate the two versions - this has less duplication, but would complicate the readability of the code somewhat.