### PR TITLE
impl Debug for CodeMap

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,10 +116,9 @@ impl<T> Deref for Spanned<T> {
 }
 
 /// A data structure recording source code files for position lookup.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct CodeMap {
     files: Vec<Arc<File>>,
-    _allow_priv: ()
 }
 
 impl CodeMap {


### PR DESCRIPTION
Useful to be able to use `#[derive(Debug)]` on structs with `CodeMap`
field.